### PR TITLE
refactor(exportPdf): 增强打印iframe的清理逻辑以提高可靠性

### DIFF
--- a/src/lib/exportPdf.ts
+++ b/src/lib/exportPdf.ts
@@ -11,7 +11,7 @@
  *   1. 创建 hidden iframe，srcdoc 写入 HTML
  *   2. 等 iframe load 事件（HTML 已 inline base64，无网络等待）
  *   3. iframe.contentWindow.print() 触发原生对话框
- *   4. afterprint 事件（或 visibilitychange 兜底）触发后清理 iframe
+ *   4. afterprint / focus / visibilitychange / 轮询焦点 任一命中后清理 iframe
  *
  * 跨平台：WebView2 / WKWebView / WebKitGTK 都支持 contentWindow.print 与原生
  * "另存为 PDF" 选项，无需额外权限。
@@ -24,11 +24,11 @@ const PRINT_FRAME_ID_PREFIX = "kb-pdf-print-frame-";
  *
  * @param html 完整的 HTML 文档字符串（必须是 self-contained，图片已 inline）
  * @param title 用作打印对话框默认文件名（浏览器会自动 sanitize）
- * @returns Promise，在 afterprint 触发或超时兜底后 resolve
+ * @returns Promise，在打印对话框关闭且 iframe 清理完成后 resolve
  */
 export function printHtmlAsPdf(html: string, title: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    // 进场先清掉可能残留的旧打印 iframe：上一次打印若 afterprint 未触发（WebView2 常见），
+    // 进场先清掉可能残留的旧打印 iframe：上一次打印若收尾信号丢失，
     // 旧 iframe 会一直挂在主文档里拖慢/卡死渲染，多次打印叠加更严重。打印前统一清场。
     document
       .querySelectorAll(`iframe[id^="${PRINT_FRAME_ID_PREFIX}"]`)
@@ -50,13 +50,45 @@ export function printHtmlAsPdf(html: string, title: string): Promise<void> {
     // 元素视口内的内容，固定一页高 → 超出部分被裁掉 → 「只能打印第一页」。这里初始给一页高
     // 兜底布局，onload 后再撑满到内容 scrollHeight，让打印引擎拿到整篇文档去分页。
     iframe.style.cssText =
-      "position:fixed;left:-99999px;top:0;width:794px;height:1123px;border:0;background:#fff;";
+      "position:fixed;left:-99999px;top:0;width:794px;height:1123px;border:0;background:#fff;pointer-events:none;";
 
     let cleaned = false;
+    let settled = false;
+    let printStartedAt = 0;
+    let pollTimer: number | null = null;
+    let forceCleanupTimer: number | null = null;
+
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+
     const cleanup = () => {
       if (cleaned) return;
       cleaned = true;
       window.removeEventListener("focus", onMainFocus);
+      document.removeEventListener("visibilitychange", onVisibilityChange, true);
+      if (pollTimer != null) {
+        window.clearInterval(pollTimer);
+        pollTimer = null;
+      }
+      if (forceCleanupTimer != null) {
+        window.clearTimeout(forceCleanupTimer);
+        forceCleanupTimer = null;
+      }
+      // 先把大 iframe 缩回极小并清空内容，再移除节点。
+      // 原因：问题现场是「关闭打印后主页面持续卡顿」——根因不是打印本身，而是超高 iframe
+      // 残留在主文档里继续参与布局/内存占用。即使 removeChild 在某些内核里延后，
+      // 先 shrink + blank 也能立刻解除主窗负担。
+      try {
+        iframe.style.width = "1px";
+        iframe.style.height = "1px";
+        iframe.srcdoc = "<!doctype html><html><head><meta charset='utf-8'></head><body></body></html>";
+        iframe.src = "about:blank";
+      } catch {
+        /* ignore */
+      }
       try {
         iframe.parentNode?.removeChild(iframe);
       } catch {
@@ -64,12 +96,24 @@ export function printHtmlAsPdf(html: string, title: string): Promise<void> {
       }
     };
 
-    // 主窗 focus 兜底：打印对话框是模态系统窗口，关闭后 Tauri 主 WebView 重新获得焦点。
-    // 这比 iframe 的 afterprint 在 WebView2 下更可靠，确保 iframe 被及时清理、不残留拖慢主窗。
+    const finish = () => {
+      cleanup();
+      settle();
+    };
+
+    // 主窗 focus 兜底：打印对话框是模态系统窗口，关闭后 Tauri 主 WebView 往往重新获得焦点。
+    // 但 WebView2 的 focus/afterprint 都不稳定，所以它只是一个信号源，不再是唯一兜底。
     const onMainFocus = () => {
-      // print() 期间主窗处于 blur，首个 focus 即对话框已关闭
-      setTimeout(cleanup, 200);
-      resolve();
+      // 某些内核会在 print() 调起瞬间也抖一次 focus；加最小时间窗，避免过早清掉 iframe。
+      if (Date.now() - printStartedAt < 300) return;
+      setTimeout(finish, 150);
+    };
+
+    // 某些系统打印 UI 不会触发 focus，但会让页面在对话框关闭后从 hidden 回到 visible。
+    const onVisibilityChange = () => {
+      if (document.hidden) return;
+      if (Date.now() - printStartedAt < 300) return;
+      setTimeout(finish, 150);
     };
 
     iframe.onload = () => {
@@ -119,30 +163,40 @@ export function printHtmlAsPdf(html: string, title: string): Promise<void> {
       // 信号 1：afterprint 事件在用户关闭打印对话框后触发（无论确认还是取消）
       const onAfterPrint = () => {
         win.removeEventListener("afterprint", onAfterPrint);
-        // 延迟清理：部分内核 print() 调用是异步的，立即移除会打断
-        setTimeout(cleanup, 200);
-        resolve();
+        setTimeout(finish, 150);
       };
       win.addEventListener("afterprint", onAfterPrint);
-      // 信号 2：主窗 focus（afterprint 在部分 WebView2 不触发时的可靠兜底）
+      // 信号 2：主窗重新获得焦点
       window.addEventListener("focus", onMainFocus);
-
-      // 信号 3：30 秒超时强制清理（极端情况下两个事件都没来时的最后保险）
-      setTimeout(() => {
-        if (!cleaned) {
-          cleanup();
-          resolve();
-        }
-      }, 30_000);
+      // 信号 3：页面从 hidden 回到 visible
+      document.addEventListener("visibilitychange", onVisibilityChange, true);
 
       try {
         // 关键调用：必须先 focus 再 print，否则部分浏览器会忽略
         win.focus();
+        printStartedAt = Date.now();
         win.print();
       } catch (e) {
         cleanup();
         reject(e);
+        return;
       }
+
+      // 信号 4：轮询 document.hasFocus() / hidden 状态。
+      // 这是给 WebView2 的保底：有些机器 afterprint 不触发、focus 也不稳定，但对话框关闭后
+      // 页面状态会恢复为「可见 + 有焦点」。一旦命中就立即清理残留 iframe。
+      pollTimer = window.setInterval(() => {
+        if (cleaned) return;
+        if (Date.now() - printStartedAt < 500) return;
+        if (!document.hidden && document.hasFocus()) {
+          finish();
+        }
+      }, 500);
+
+      // 信号 5：绝对兜底超时。即便所有事件都丢了，也不能把超高 iframe 永久留在主页面里。
+      forceCleanupTimer = window.setTimeout(() => {
+        if (!cleaned) finish();
+      }, 10_000);
     };
 
     iframe.onerror = (e) => {


### PR DESCRIPTION
更新了印刷iframe的清理过程，以处理各种关闭信号，包括后印、焦点和可信度变化。引入了一种民意调查机制，以确保及时清理并防止由挥之不去的iframe引起的性能问题。为了清晰起见，调整了评论和返回值。

## 📋 变更概述

- 修复“打印成 PDF / 系统打印”关闭后主页面持续卡顿的问题。
- 加固打印 iframe 的收尾流程，不再只依赖单一事件，补充 afterprint、窗口 focus、visibilitychange、焦点轮询和超时兜底，多路径确保打印结束后能正确释放资源。
- 优化打印清理动作，在移除 iframe 前先缩小尺寸并清空内容，避免超高打印文档残留在页面中继续参与布局，降低卡顿和内存占用风险。
- 排查并确认当前打印链路仍存在“长内容可能被截断、展示不全”的结构性风险，已定位到打印高度测量时机与分页规则两个关键方向，作为下一步修复重点。
- 补齐本地开发所需的 kb-mcp sidecar 产物，解决 pnpm tauri dev 启动时因缺少 binaries/kb-mcp-x86_64-pc-windows-msvc.exe 导致的构建失败问题。


## 🔖 变更类型

1. 🐛 Bug 修复（fix）
2. ✨ 新功能（feat）
3. 📝 文档（docs）
4. 🎨 代码风格（style）
5. ♻️ 重构（refactor）
6. ⚡ 性能优化（perf）
7. ✅ 测试（test）
8. 🔨 构建/工具（build / chore）

## 🔗 关联 Issue

Fixes #38


## ✅ 测试清单

- [X] 本地运行通过：`pnpm tauri dev`
- [X] Rust 编译检查通过：`cd src-tauri && cargo check`
- [X] Rust 代码检查通过：`cd src-tauri && cargo clippy`（无新增 warning）
- [X] TypeScript 类型检查通过：`npx tsc --noEmit`
- [X] 相关功能已手动验证（请在 "其他说明" 描述测试场景）
- [X] 未修改 `LICENSE` / `COMMERCIAL-LICENSE.md` 等法律文件

## 📜 贡献者许可协议（CLA）⚠️ **必须全部勾选**

> 详见 [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)

- [X] 我已阅读并**同意** [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) 中的全部贡献者许可协议（CLA）条款
- [X] 我**拥有**本 PR 中所贡献代码的完整著作权（或已获得权利人授权）
- [X] 我**授予**项目作者**永久、全球、免费、可再授权**的使用权，包括以 **AGPL-3.0 或其他许可证（含商业授权）** 再授权本贡献
- [X] 我**保证**本次贡献不违反任何第三方权利（专利、版权、商业秘密、NDA 等）
- [X] 我理解本贡献将以 **AGPL-3.0** 向公众发布
- [X] 我**放弃**对本项目作者就本次贡献的任何专利权利主张

**⚠️ 未勾选以上全部 CLA 条款的 PR 将被自动关闭，不予审核。**
